### PR TITLE
Approach #2 - UseState within context component

### DIFF
--- a/src/components/CartButtons.js
+++ b/src/components/CartButtons.js
@@ -1,35 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FaShoppingCart, FaUserMinus, FaUserPlus } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { useProductsContext } from '../context/products_context';
-import axios, { AxiosError } from 'axios';
-
-const rootUrl = 'https://ecommerce-6kwa.onrender.com';
+import { useUserContext } from '../context/user_context';
 
 //vart-btn-wrapper- global class- see in Navbar.js it is display none on a default screen, nested class in NavContainer = styled...
 const CartButtons = () => {
   const { closeSidebar } = useProductsContext(); // extracting the closeSidebar function from the returned object from useProductsContext() and assigning it to a variable named closeSidebar.
-  const [currentUser, setCurrentUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchData() {
-      const url = `${rootUrl}/api/v1/users/showMe`;
-      axios
-        .get(url, { withCredentials: true })
-        .then((response) => {
-          console.log(response);
-          setCurrentUser(response.data.user);
-        })
-        .catch((error) => {
-          const errorPayload =
-            error instanceof AxiosError ? error.response.data : error;
-          console.error(errorPayload);
-        });
-    }
-    fetchData();
-    // By using empty array [], for the "dependencies" argument of useEffect, it tells React to run this useEffect hook only *once*, the first time this component/context is rendered
-  }, []);
+  const { currentUser } = useUserContext();
 
   return (
     <Wrapper className='cart-btn-wrapper'>

--- a/src/context/user_context.js
+++ b/src/context/user_context.js
@@ -1,0 +1,114 @@
+import React, { useContext, useEffect, useState } from 'react';
+import axios, { AxiosError } from 'axios';
+
+// Since this rootURL is used throughout the app, it might make sense to instead have a file for "Constants" that can be imported wherever needed
+const rootUrl = 'https://ecommerce-6kwa.onrender.com';
+
+const UserContext = React.createContext();
+
+export const UserProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [authLoading, setAuthLoading] = useState(false);
+  const [authError, setAuthError] = useState(false);
+
+  useEffect(() => {
+    async function fetchData() {
+      const url = `${rootUrl}/api/v1/users/showMe`;
+      axios
+        .get(url, { withCredentials: true })
+        .then((response) => {
+          console.log(response);
+          setCurrentUser(response.data.user);
+        })
+        .catch((error) => {
+          const errorPayload =
+            error instanceof AxiosError ? error.response.data : error;
+          console.error(errorPayload);
+          setAuthError(errorPayload);
+        });
+    }
+    fetchData();
+    // By using empty array [], for the "dependencies" argument of useEffect, it tells React to run this useEffect hook only *once*, the first time this component/context is rendered
+  }, []);
+
+  const handleLogin = async (userCredentials) => {
+    setAuthLoading(true);
+    try {
+      const url = `${rootUrl}/api/v1/auth/login`;
+      // We could use fetch or axios. Fetch is native to the browser (doesn't need extra libs), but since we already have axios in use in this repo, I'll stick to using that. It's a little bit cleaner too than raw fetch, but either one is fine.
+      const response = await axios.post(url, userCredentials, {
+        withCredentials: true,
+      });
+      console.log(response);
+      setAuthLoading(false);
+      setCurrentUser(response.data.user);
+      return true;
+    } catch (error) {
+      console.error(error);
+      const errorPayload =
+        error instanceof AxiosError ? error.response.data : error;
+      setAuthLoading(false);
+      setAuthError(errorPayload);
+      return false;
+    }
+  };
+
+  const handleRegister = async (userCredentials) => {
+    setAuthLoading(true);
+    try {
+      const url = `${rootUrl}/api/v1/auth/register`;
+      const response = await axios.post(url, userCredentials, {
+        withCredentials: true,
+      });
+      console.log(response);
+      setCurrentUser(response.data.user);
+      setAuthLoading(false);
+      return true;
+    } catch (error) {
+      console.error(error);
+      const errorPayload =
+        error instanceof AxiosError ? error.response.data : error;
+      setAuthError(errorPayload);
+      setAuthLoading(false);
+      return false;
+    }
+  };
+
+  const handleLogout = async () => {
+    setAuthLoading(true);
+    try {
+      const url = `${rootUrl}/api/v1/auth/logout`;
+      const response = await axios.get(url);
+      console.log(response);
+      setCurrentUser(null);
+      setAuthLoading(false);
+      return true;
+    } catch (error) {
+      console.error(error);
+      const errorPayload =
+        error instanceof AxiosError ? error.response.data : error;
+      setAuthError(errorPayload);
+      setAuthLoading(false);
+      return false;
+    }
+  };
+
+  return (
+    <UserContext.Provider
+      value={{
+        handleLogin,
+        handleRegister,
+        handleLogout,
+        currentUser,
+        authLoading,
+        authError,
+      }}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+};
+// make sure use
+export const useUserContext = () => {
+  return useContext(UserContext);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,13 @@ import './index.css';
 import App from './App';
 
 import { ProductsProvider } from './context/products_context';
-import { FilterProvider } from './context/filter_context';
-import { CartProvider } from './context/cart_context';
-import { Auth0Provider } from '@auth0/auth0-react';
-
+import { UserProvider } from './context/user_context';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
-  <ProductsProvider>
-    <App />
-  </ProductsProvider>
+  <UserProvider>
+    <ProductsProvider>
+      <App />
+    </ProductsProvider>
+  </UserProvider>
 );

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,33 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { FeaturedProducts, Hero, Services, Contact } from '../components';
 import AddProduct from './AddProduct';
-import axios, { AxiosError } from 'axios';
+import { useUserContext } from '../context/user_context';
 
-const rootUrl = 'https://ecommerce-6kwa.onrender.com';
 const HomePage = () => {
-  const [currentUser, setCurrentUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchData() {
-      const url = `${rootUrl}/api/v1/users/showMe`;
-      axios
-        .get(url, { withCredentials: true })
-        .then((response) => {
-          console.log(response);
-          setCurrentUser(response.data.user);
-        })
-        .catch((error) => {
-          const errorPayload =
-            error instanceof AxiosError ? error.response.data : error;
-          console.error(errorPayload);
-        });
-    }
-    fetchData();
-    // By using empty array [], for the "dependencies" argument of useEffect, it tells React to run this useEffect hook only *once*, the first time this component/context is rendered
-  }, []);
-
+  const { currentUser } = useUserContext();
   const isAdminLoggedIn = currentUser?.role === 'admin';
-  // need to check here if user.role === 'admin'- show <AddProduct/> component
 
   return (
     <main>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,34 +1,13 @@
 import React, { useState } from 'react';
 import { Link, Redirect } from 'react-router-dom';
-import axios, { AxiosError } from 'axios';
-
-const rootUrl = 'https://ecommerce-6kwa.onrender.com';
+import { useUserContext } from '../context/user_context';
 
 const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [redirectToHome, setRedirectToHome] = useState(false);
   const [userName, setUserName] = useState('');
-  const [loginLoading, setLoginLoading] = useState(false);
-
-  const handleLogin = async (userCredentials) => {
-    setLoginLoading(true);
-    try {
-      const url = `${rootUrl}/api/v1/auth/login`;
-      const response = await axios.post(url, userCredentials, {
-        withCredentials: true,
-      });
-      console.log(response);
-      setLoginLoading(false);
-      return true;
-    } catch (error) {
-      const errorPayload =
-        error instanceof AxiosError ? error.response.data : error;
-      console.error(errorPayload);
-      setLoginLoading(false);
-      return false;
-    }
-  };
+  const { handleLogin, authLoading, authError } = useUserContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -46,8 +25,12 @@ const Login = () => {
     return <Redirect to='/' />;
   }
 
-  if (loginLoading) {
+  if (authLoading) {
     return <span>Logging in...</span>;
+  }
+
+  if (authError) {
+    return <span>Encountered error logging in</span>;
   }
 
   return (

--- a/src/pages/Logout.js
+++ b/src/pages/Logout.js
@@ -1,36 +1,21 @@
 import React, { useState } from 'react';
-import { Redirect } from 'react-router-dom';
-import axios, { AxiosError } from 'axios';
-
-const rootUrl = 'https://ecommerce-6kwa.onrender.com';
+import { Link, Redirect } from 'react-router-dom';
+import { useUserContext } from '../context/user_context';
 
 const Logout = () => {
   const [redirectToHome, setRedirectToHome] = useState(false);
-  const [logoutLoading, setLogoutLoading] = useState(false);
-
-  const handleLogout = async () => {
-    setLogoutLoading(true);
-    try {
-      const url = `${rootUrl}/api/v1/auth/logout`;
-      const response = await axios.get(url);
-      console.log(response);
-      setLogoutLoading(false);
-      return true;
-    } catch (error) {
-      const errorPayload =
-        error instanceof AxiosError ? error.response.data : error;
-      console.error(errorPayload);
-      setLogoutLoading(false);
-      return false;
-    }
-  };
+  const { handleLogout, authLoading, authError } = useUserContext();
 
   if (redirectToHome) {
     return <Redirect to='/' />;
   }
 
-  if (logoutLoading) {
-    return <span>Logging you out...</span>;
+  if (authLoading) {
+    return <span>Logging out...</span>;
+  }
+
+  if (authError) {
+    return <span>Encountered error logging out</span>;
   }
 
   return (

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -1,34 +1,13 @@
 import React, { useState } from 'react';
 import { Link, Redirect } from 'react-router-dom';
-import axios, { AxiosError } from 'axios';
-
-const rootUrl = 'https://ecommerce-6kwa.onrender.com';
+import { useUserContext } from '../context/user_context';
 
 const Register = () => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [redirectToHome, setRedirectToHome] = useState(false);
-  const [registerLoading, setRegisterLoading] = useState(false);
-
-  const handleRegister = async (userCredentials) => {
-    setRegisterLoading(true);
-    try {
-      const url = `${rootUrl}/api/v1/auth/register`;
-      const response = await axios.post(url, userCredentials, {
-        withCredentials: true,
-      });
-      console.log(response);
-      setRegisterLoading(false);
-      return true;
-    } catch (error) {
-      const errorPayload =
-        error instanceof AxiosError ? error.response.data : error;
-      console.error(errorPayload);
-      setRegisterLoading(false);
-      return false;
-    }
-  };
+  const { handleRegister, authLoading, authError } = useUserContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -47,8 +26,12 @@ const Register = () => {
     return <Redirect to='/' />;
   }
 
-  if (registerLoading) {
+  if (authLoading) {
     return <span>Registering...</span>;
+  }
+
+  if (authError) {
+    return <span>Encountered error registering</span>;
   }
 
   return (

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -40,7 +40,8 @@ export const services = [
 ];
 
 //export const products_url = 'https://course-api.com/react-store-products'
-export const products_url = 'https://ecommerce-6kwa.onrender.com/api/v1/products';
+export const products_url =
+  'https://ecommerce-6kwa.onrender.com/api/v1/products';
 //export const single_product_url = `https://course-api.com/react-store-single-product/api/v1/products?id=`
 export const single_product_url = `https://ecommerce-6kwa.onrender.com/api/v1/products`;
 //point of access to my api


### PR DESCRIPTION
As I explained in [Approach #1](https://github.com/akosasante/akos-reactEcommerce/pull/3), having all our auth logic strewn across components is not great, and can lead to a lot of duplication. It also makes it harder to share common state among sibling components.

Instead, here I will show moving all of that auth logic into the `UserContext` component. Contexts are a way to share global data in React: https://react.dev/learn/passing-data-deeply-with-context && https://react.dev/reference/react/useContext

We shouldn't [over use](https://kentcdodds.com/blog/application-state-management-with-react) them, but auth is a good common usecase for contexts.